### PR TITLE
use OPTARG to get args

### DIFF
--- a/check_rpi.sh
+++ b/check_rpi.sh
@@ -126,11 +126,11 @@ do
 		MYCHECK=temperature
 		;;
         w)
-                WARNLEVEL=$3
+                WARNLEVEL=$OPTARG
 		CUSTOMWARNCRIT=1
                 ;;
         c)
-                CRITLEVEL=$5
+                CRITLEVEL=$OPTARG
 		CUSTOMWARNCRIT=1
                 ;;
 	*)


### PR DESCRIPTION
icinga2 (at least r2.4.1-1) passes args in alphabetical order which breaks the usage of $x
